### PR TITLE
implement configuration for smtp auth and starttls

### DIFF
--- a/provisioning/salt/roots/pillar/pypi-deploys/pypi-dev.sls
+++ b/provisioning/salt/roots/pillar/pypi-deploys/pypi-dev.sls
@@ -13,12 +13,7 @@ pypi-deploy-devpypi:
     type: local
     uri: None
 
-  mailhost: localhost:25
-
   https_only: True
   server_names:
     - 192.168.57.9
   url: http://192.168.57.9
-
-  uwsgi:
-    processes: 2

--- a/provisioning/salt/roots/pillar/pypi-deploys/testpypi.sls
+++ b/provisioning/salt/roots/pillar/pypi-deploys/testpypi.sls
@@ -12,12 +12,7 @@ pypi-deploy-testpypi:
     type: glusterfs
     uri: 172.16.57.30:/testpypi
 
-  mailhost: localhost:25
-
   https_only: True
   server_names:
     - testpypi.python.org
   url: https://testpypi.python.org
-
-  uwsgi:
-    processes: 2

--- a/provisioning/salt/roots/pillar/secrets/pypi-dev.sls
+++ b/provisioning/salt/roots/pillar/secrets/pypi-dev.sls
@@ -17,6 +17,15 @@ secrets-pypi-deploy-devpypi:
   fastly:
     api_key: ''
     service_id: ''
+  uwsgi:
+    processes: 2
+  mailhost: localhost:25
+  smtp:
+    hostname: localhost
+    starttls: 'off'
+    auth: 'off'
+    login: None
+    password: None
   pubkey: |
     -----BEGIN PUBLIC KEY-----
     publiclolnope

--- a/provisioning/salt/roots/pillar/secrets/testpypi.sls
+++ b/provisioning/salt/roots/pillar/secrets/testpypi.sls
@@ -17,6 +17,15 @@ secrets-pypi-deploy-testpypi:
   fastly:
     api_key: deadbeef
     service_id: deadbeef
+  uwsgi:
+    processes: 2
+  mailhost: localhost:25
+  smtp:
+    hostname: localhost
+    starttls: 'off'
+    auth: 'off'
+    login: None
+    password: None
   pubkey: |
     -----BEGIN PUBLIC KEY-----
     publiclolnope

--- a/provisioning/salt/roots/prod-pillar/pypi-deploys/testpypi.sls
+++ b/provisioning/salt/roots/prod-pillar/pypi-deploys/testpypi.sls
@@ -12,13 +12,8 @@ pypi-deploy-testpypi:
     type: glusterfs
     uri: 172.16.57.6:/testpypi
 
-  mailhost: localhost:25
-
   https_only: True
   server_names:
     - testpypi.python.org
     - testpypi.a.ssl.fastly.net
   url: https://testpypi.python.org
-
-  uwsgi:
-    processes: 2

--- a/provisioning/salt/roots/salt/pypi/config/pypi.ini.jinja
+++ b/provisioning/salt/roots/salt/pypi/config/pypi.ini.jinja
@@ -27,7 +27,7 @@ rss_file = {{ config['data_mount'] }}/pypi_rss.xml
 packages_rss_file = {{ config['data_mount'] }}/pypi_packages_rss.xml
 
 ; Email
-mailhost = {{ config['mailhost'] }}
+mailhost = {{ secrets.get('mailhost', 'localhost:25') }}
 adminemail = cheeseshop@python.org
 replyto = cheeseshop@python.org
 
@@ -48,12 +48,20 @@ files_url = {{ config['url'] }}/packages/
 pydotorg = https://www.python.org/
 package_docs_url = http://pythonhosted.org/
 
+[smtp]
+hostname = {{ secrets['smtp']['hostname'] }}
+starttls = {{ secrets['smtp'].get('starttls', 'off') }}
+auth = {{ secrets['smtp'].get('auth', 'off') }}
+login = {{ secrets['smtp'].get('login', '') }}
+password = {{ secrets['smtp'].get('password', '') }}
+
 [passlib]
 schemes = django_bcrypt, unix_disabled
 
 [logging]
 file = /var/log/{{ config['name'] }}/pypi.log
-mailhost = {{ secrets['logging']['mailhost'] }}
+mail_logger = {{ secrets['logging'].get('mail_logger', 'off') }}
+mailhost = {{ secrets['logging'].get('mailhost', '') }}
 fromaddr = {{ secrets['logging']['fromaddr'] }}
 toaddrs = {{ secrets['logging']['toaddrs'] }}
 
@@ -67,7 +75,7 @@ wsgi-file = {{ config['path'] }}/src/pypi.wsgi
 socket = /var/run/{{ config['name'] }}/pypi.sock
 pidfile = /var/run/{{ config['name'] }}/pypi.pid
 daemonize = 127.0.0.1:8224
-processes = {{ config['uwsgi']['processes'] }}
+processes = {{ secrets['uwsgi'].get('processes', 2) }}
 harakiri = 60
 reload-on-as = 400
 max-requests = 10000


### PR DESCRIPTION
This is a sister PR for https://bitbucket.org/pypa/pypi/pull-request/9
- Implements configuration options for smtp authentication and starttls
- Merges all config.ini specific keys into the secrets pillar
