### PR TITLE
Upgrade to latest pypi-cdn-log-archiver.

### DIFF
--- a/provisioning/salt/roots/salt/pypi/log.sls
+++ b/provisioning/salt/roots/salt/pypi/log.sls
@@ -43,7 +43,7 @@ redis-daemon:
 
 pypi-cdn-log-archiver:
   pip.installed:
-    - name: pypi-cdn-log-archiver == 0.1.4
+    - name: pypi-cdn-log-archiver == 0.1.5
     - bin_env: /opt/pypi-cdn-log-archiver/env
     - require:
       - virtualenv: /opt/pypi-cdn-log-archiver/env


### PR DESCRIPTION
- Enables lzma compression
- Enables mergine of log files into one
