### PR TITLE
keep 24 hours of cdn logs locally, rotated/compressed hourly

### DIFF
--- a/provisioning/salt/roots/salt/pypi/config/pypi-syslog.logrotate.conf
+++ b/provisioning/salt/roots/salt/pypi/config/pypi-syslog.logrotate.conf
@@ -1,10 +1,11 @@
 /var/log/cdn/{{ syslog_name }}/*.log {
-    daily
-    rotate 3
+    rotate 24
     missingok
     notifempty
     compress
     sharedscripts
+    dateext
+    dateformat -%Y-%m-%d-%s
     postrotate
         /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
     endscript

--- a/provisioning/salt/roots/salt/pypi/log.sls
+++ b/provisioning/salt/roots/salt/pypi/log.sls
@@ -111,11 +111,20 @@ pypi-cdn-log-archiver:
       syslog_name: {{ config['fastly_syslog_name'] }}
 
 /etc/logrotate.d/{{ config['name'] }}-cdn:
+  file.absent
+
+/etc/logrotate-{{config['name']}}-cdn.conf:
   file.managed:
     - source: salt://pypi/config/pypi-syslog.logrotate.conf
     - template: jinja
     - context:
       syslog_name: {{ config['fastly_syslog_name'] }}
+
+{{config['name']}}-hourly-logrotate-cron:
+  cron.present:
+    - name: /usr/sbin/logrotate -f /etc/logrotate-{{config['name']}}-cdn.conf
+    - minute: '0'
+    - user: root
 
 {% if 'cron_workers' in grains['roles'] %}
 {{ config['user'] }}-integrate-stats-cron:


### PR DESCRIPTION
stabilize our log volume on the nodes which receive the syslog stream from fastly.